### PR TITLE
Union / Interface type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 1.1.0
+
+* Feature: Support fragments on interfaces and unions via a new `fragmentIntrospectionQueryResultData` option.
+
+# 1.0.0
+
+Initial version.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ This function is called when an error occurs while resolving a query from the mo
 
 By default, this will print the query and errors to `console.error`. You can also pass a no-op function to suppress this behavior.
 
+`opts.fragmentIntrospectionQueryResultData?: IntrospectionResultData`
+
+```ts
+interface IntrospectionResultData {
+  __schema: {
+    types: {
+      kind: string;
+      name: string;
+      possibleTypes: {
+        name: string;
+      }[];
+    }[];
+  };
+}
+```
+
+If your queries contain fragments on union or interface types, you will need to provide this option so that the MockLinkGraph can distinguish between types. See https://www.apollographql.com/docs/react/advanced/fragments.html#fragment-matcher for more details on why this is needed and how to extract this data from your schema.
+
 ### MockGraphError
 
 ```ts

--- a/src/MockGraphLink.js
+++ b/src/MockGraphLink.js
@@ -168,7 +168,7 @@ class MockGraphLink extends ApolloLink {
               errors.push({
                 type: 'unionInterfaceTypes',
                 path: currentPath,
-                fragmentName: fragment.name.value,
+                fragmentName: fragment.name && fragment.name.value,
                 objectType,
                 fragmentType,
               });
@@ -294,12 +294,12 @@ class MockGraphLink extends ApolloLink {
             } because __typename is missing from the mock graph`;
           } else if (e.type === 'unionInterfaceTypes') {
             message = `Can't resolve fragment ${
-              e.fragmentName
-            } because its type (${
+              e.fragmentName ? e.fragmentName + ' ' : ''
+            }because its type (${
               e.fragmentType
             }) might not match the object's type (${
               e.objectType
-            }). In order to hande union and interface types, you must pass \`fragmentIntrospectionQueryResultData\` when creating MockGraphLink. See https://github.com/dallonf/apollo-link-mock-graph/blob/master/README.md for details.`;
+            }). In order to handle union and interface types, you must pass \`fragmentIntrospectionQueryResultData\` when creating MockGraphLink. See https://github.com/dallonf/apollo-link-mock-graph/blob/master/README.md for details.`;
           }
           message = `${formatPath(e.path)}: ${message}`;
           return {

--- a/src/MockGraphLink.js
+++ b/src/MockGraphLink.js
@@ -43,6 +43,7 @@ class MockGraphLink extends ApolloLink {
     }
   }
 
+  // Modified version of https://github.com/apollographql/apollo-client/blob/b1ca2025d13a9a446be3b7fda2483767d3f61a6e/packages/apollo-cache-inmemory/src/fragmentMatcher.ts#L148
   parseFragmentIntrospectionResult(introspectionResultData) {
     const typeMap = {};
     introspectionResultData.__schema.types.forEach(type => {
@@ -155,7 +156,10 @@ class MockGraphLink extends ApolloLink {
             executeFragment();
           } else {
             if (this.fragmentTypeMap) {
-              if (this.fragmentTypeMap[fragmentType] && this.fragmentTypeMap[fragmentType].indexOf(objectType) !== -1) {
+              if (
+                this.fragmentTypeMap[fragmentType] &&
+                this.fragmentTypeMap[fragmentType].indexOf(objectType) !== -1
+              ) {
                 executeFragment();
               } else {
                 // the fragment isn't a matching type. Ignore.

--- a/test/MockGraphLink.test.js
+++ b/test/MockGraphLink.test.js
@@ -10,6 +10,7 @@ const createClient = (getMockGraph, { introspectionQueryResultData } = {}) => {
   const onError = jest.fn();
   const link = new MockGraphLink(getMockGraph, {
     onError,
+    fragmentIntrospectionQueryResultData: introspectionQueryResultData,
   });
   const fragmentMatcher = introspectionQueryResultData
     ? new IntrospectionFragmentMatcher({

--- a/test/MockGraphLink.test.js
+++ b/test/MockGraphLink.test.js
@@ -189,3 +189,74 @@ it('handles arrays', async () => {
   });
   expect(onError).not.toHaveBeenCalled();
 });
+
+it('handles inline fragments on type unions', async () => {
+  const query = gql`
+    {
+      posts {
+        id
+        title
+        ... on PhotoPost {
+          photoUrl
+        }
+        ... on VideoPost {
+          youtubeId
+        }
+        ... on TextPost {
+          body
+        }
+      }
+    }
+  `;
+  const expectedResult = {
+    posts: [
+      {
+        id: '1',
+        title: 'Need some help',
+        body:
+          'How much wood could a woodchuck chuck if woodchuck could chuck wood? Asking for a friend.',
+      },
+      {
+        id: '2',
+        title: 'Look at this cat!',
+        photoUrl: 'https://http.cat/503',
+      },
+      {
+        id: '3',
+        title: 'Check out this new single from my band',
+        youtubeId: 'dQw4w9WgXcQ',
+      },
+    ],
+  };
+  const mockGraph = {
+    Query: {
+      posts: [
+        {
+          __typename: 'TextPost',
+          id: '1',
+          title: 'Need some help',
+          body:
+            'How much wood could a woodchuck chuck if woodchuck could chuck wood? Asking for a friend.',
+        },
+        {
+          __typename: 'PhotoPost',
+          id: '2',
+          title: 'Look at this cat!',
+          photoUrl: 'https://http.cat/503',
+        },
+        {
+          __typename: 'VideoPost',
+          id: '3',
+          title: 'Check out this new single from my band',
+          youtubeId: 'dQw4w9WgXcQ',
+        },
+      ],
+    },
+  };
+  const { client, onError } = createClient(() => mockGraph);
+  const result = await client.query({
+    query,
+  });
+  expect(result.data).toEqual(expectedResult);
+  expect(onError).not.toHaveBeenCalled();
+});

--- a/test/MockGraphLink.test.js
+++ b/test/MockGraphLink.test.js
@@ -1,14 +1,29 @@
 import { ApolloClient } from 'apollo-client';
-import { InMemoryCache } from 'apollo-cache-inmemory';
+import {
+  InMemoryCache,
+  IntrospectionFragmentMatcher,
+} from 'apollo-cache-inmemory';
 import gql from 'graphql-tag';
 import MockGraphLink from '../src/MockGraphLink';
 
-const createClient = getMockGraph => {
+const createClient = (getMockGraph, { introspectionQueryResultData } = {}) => {
   const onError = jest.fn();
   const link = new MockGraphLink(getMockGraph, {
     onError,
   });
-  const client = new ApolloClient({ link, cache: new InMemoryCache() });
+  const fragmentMatcher = introspectionQueryResultData
+    ? new IntrospectionFragmentMatcher({
+        introspectionQueryResultData,
+      })
+    : undefined;
+  const cacheOptions = {};
+  if (fragmentMatcher) {
+    cacheOptions.fragmentMatcher = fragmentMatcher;
+  }
+  const client = new ApolloClient({
+    link,
+    cache: new InMemoryCache(cacheOptions),
+  });
   return { client, onError };
 };
 
@@ -195,33 +210,40 @@ it('handles inline fragments on type unions', async () => {
     {
       posts {
         id
-        title
-        ... on PhotoPost {
-          photoUrl
-        }
-        ... on VideoPost {
-          youtubeId
-        }
-        ... on TextPost {
-          body
-        }
+        ...PostView
+      }
+    }
+
+    fragment PostView on Post {
+      title
+      ... on PhotoPost {
+        photoUrl
+      }
+      ... on VideoPost {
+        youtubeId
+      }
+      ... on TextPost {
+        body
       }
     }
   `;
   const expectedResult = {
     posts: [
       {
+        __typename: 'TextPost',
         id: '1',
         title: 'Need some help',
         body:
           'How much wood could a woodchuck chuck if woodchuck could chuck wood? Asking for a friend.',
       },
       {
+        __typename: 'PhotoPost',
         id: '2',
         title: 'Look at this cat!',
         photoUrl: 'https://http.cat/503',
       },
       {
+        __typename: 'VideoPost',
         id: '3',
         title: 'Check out this new single from my band',
         youtubeId: 'dQw4w9WgXcQ',
@@ -253,7 +275,23 @@ it('handles inline fragments on type unions', async () => {
       ],
     },
   };
-  const { client, onError } = createClient(() => mockGraph);
+  const { client, onError } = createClient(() => mockGraph, {
+    introspectionQueryResultData: {
+      __schema: {
+        types: [
+          {
+            kind: 'INTERFACE',
+            name: 'Post',
+            possibleTypes: [
+              { name: 'TextPost' },
+              { name: 'PhotoPost' },
+              { name: 'VideoPost' },
+            ],
+          },
+        ],
+      },
+    },
+  });
   const result = await client.query({
     query,
   });

--- a/test/__snapshots__/errors.test.js.snap
+++ b/test/__snapshots__/errors.test.js.snap
@@ -1,5 +1,126 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`fails on non-matching fragments without fragmentIntrospectionQueryResultData config 1`] = `[Error: GraphQL error: currentUser: Can't resolve fragment because its type (PremiumUser) might not match the object's type (FreeUser). In order to handle union and interface types, you must pass \`fragmentIntrospectionQueryResultData\` when creating MockGraphLink. See https://github.com/dallonf/apollo-link-mock-graph/blob/master/README.md for details.]`;
+
+exports[`fails on non-matching fragments without fragmentIntrospectionQueryResultData config 2`] = `
+Array [
+  Array [
+    Object {
+      "fragmentName": undefined,
+      "fragmentType": "PremiumUser",
+      "message": "currentUser: Can't resolve fragment because its type (PremiumUser) might not match the object's type (FreeUser). In order to handle union and interface types, you must pass \`fragmentIntrospectionQueryResultData\` when creating MockGraphLink. See https://github.com/dallonf/apollo-link-mock-graph/blob/master/README.md for details.",
+      "objectType": "FreeUser",
+      "path": Array [
+        "currentUser",
+      ],
+      "type": "unionInterfaceTypes",
+    },
+  ],
+  Object {
+    "definitions": Array [
+      Object {
+        "directives": Array [],
+        "kind": "OperationDefinition",
+        "name": Object {
+          "kind": "Name",
+          "value": "MyQuery",
+        },
+        "operation": "query",
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "name": Object {
+                "kind": "Name",
+                "value": "currentUser",
+              },
+              "selectionSet": Object {
+                "kind": "SelectionSet",
+                "selections": Array [
+                  Object {
+                    "alias": undefined,
+                    "arguments": Array [],
+                    "directives": Array [],
+                    "kind": "Field",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "id",
+                    },
+                    "selectionSet": undefined,
+                  },
+                  Object {
+                    "alias": undefined,
+                    "arguments": Array [],
+                    "directives": Array [],
+                    "kind": "Field",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "name",
+                    },
+                    "selectionSet": undefined,
+                  },
+                  Object {
+                    "directives": Array [],
+                    "kind": "InlineFragment",
+                    "selectionSet": Object {
+                      "kind": "SelectionSet",
+                      "selections": Array [
+                        Object {
+                          "alias": undefined,
+                          "arguments": Array [],
+                          "directives": Array [],
+                          "kind": "Field",
+                          "name": Object {
+                            "kind": "Name",
+                            "value": "nextPaymentDate",
+                          },
+                          "selectionSet": undefined,
+                        },
+                        Object {
+                          "kind": "Field",
+                          "name": Object {
+                            "kind": "Name",
+                            "value": "__typename",
+                          },
+                        },
+                      ],
+                    },
+                    "typeCondition": Object {
+                      "kind": "NamedType",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "PremiumUser",
+                      },
+                    },
+                  },
+                  Object {
+                    "kind": "Field",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "__typename",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        "variableDefinitions": Array [],
+      },
+    ],
+    "kind": "Document",
+    "loc": Object {
+      "end": 146,
+      "start": 0,
+    },
+  },
+]
+`;
+
 exports[`handles a lot of errors 1`] = `
 [Error: GraphQL error: userById({"id":"123"}).id: Field is missing from mock graph
 GraphQL error: userById({"id":"123"}).firstName: Field is missing from mock graph
@@ -564,6 +685,137 @@ Array [
     "kind": "Document",
     "loc": Object {
       "end": 89,
+      "start": 0,
+    },
+  },
+]
+`;
+
+exports[`reports a fragment on an object without a typename 1`] = `
+[Error: GraphQL error: currentUser: Can't resolve fragment UserView because __typename is missing from the mock graph
+GraphQL error: currentUser.__typename: Field is missing from mock graph]
+`;
+
+exports[`reports a fragment on an object without a typename 2`] = `
+Array [
+  Array [
+    Object {
+      "fragmentName": "UserView",
+      "message": "currentUser: Can't resolve fragment UserView because __typename is missing from the mock graph",
+      "path": Array [
+        "currentUser",
+      ],
+      "type": "noTypename",
+    },
+    Object {
+      "message": "currentUser.__typename: Field is missing from mock graph",
+      "path": Array [
+        "currentUser",
+        "__typename",
+      ],
+      "type": "missing",
+    },
+  ],
+  Object {
+    "definitions": Array [
+      Object {
+        "directives": Array [],
+        "kind": "OperationDefinition",
+        "name": Object {
+          "kind": "Name",
+          "value": "MyQuery",
+        },
+        "operation": "query",
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "name": Object {
+                "kind": "Name",
+                "value": "currentUser",
+              },
+              "selectionSet": Object {
+                "kind": "SelectionSet",
+                "selections": Array [
+                  Object {
+                    "alias": undefined,
+                    "arguments": Array [],
+                    "directives": Array [],
+                    "kind": "Field",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "id",
+                    },
+                    "selectionSet": undefined,
+                  },
+                  Object {
+                    "directives": Array [],
+                    "kind": "FragmentSpread",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "UserView",
+                    },
+                  },
+                  Object {
+                    "kind": "Field",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "__typename",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        "variableDefinitions": Array [],
+      },
+      Object {
+        "directives": Array [],
+        "kind": "FragmentDefinition",
+        "name": Object {
+          "kind": "Name",
+          "value": "UserView",
+        },
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "name": Object {
+                "kind": "Name",
+                "value": "name",
+              },
+              "selectionSet": undefined,
+            },
+            Object {
+              "kind": "Field",
+              "name": Object {
+                "kind": "Name",
+                "value": "__typename",
+              },
+            },
+          ],
+        },
+        "typeCondition": Object {
+          "kind": "NamedType",
+          "name": Object {
+            "kind": "Name",
+            "value": "User",
+          },
+        },
+      },
+    ],
+    "kind": "Document",
+    "loc": Object {
+      "end": 138,
       "start": 0,
     },
   },


### PR DESCRIPTION
Add support for polymorphic patterns in GraphQL queries. I decided to imitate [Apollo Client's solution](https://www.apollographql.com/docs/react/advanced/fragments.html#fragment-matcher) to a very similar problem in the same space, so that you could use the same configuration you were likely already using for Apollo Client.