### PR TITLE
New timeout / wait features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.0
+
+* Feature: new `timeoutMs` option to customize the delay
+* Feature: new `link.waitForQueries()` function
+
 # 1.1.0
 
 * Feature: Support fragments on interfaces and unions via a new `fragmentIntrospectionQueryResultData` option.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ If your queries contain fragments on union or interface types, you will need to 
 
 You can customize the time delay before a query resolves. Defaults to 100ms.
 
+#### `MockGraphLink.waitForQueries(opts: { waitToSettle?: boolean }?): Promise`
+
+Useful for testing; returns a promise that resolves when all active queries have resolved.
+
+`opts.waitToSettle?: boolean`
+
+Defaults to true. When true, will also check to see if any resolved queries have caused _other_ queries to start, and if so, will wait for those, too.
+
 ### MockGraphError
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ interface IntrospectionResultData {
 
 If your queries contain fragments on union or interface types, you will need to provide this option so that the MockLinkGraph can distinguish between types. See https://www.apollographql.com/docs/react/advanced/fragments.html#fragment-matcher for more details on why this is needed and how to extract this data from your schema.
 
+`opts.timeoutMs?: number`
+
+You can customize the time delay before a query resolves. Defaults to 100ms.
+
 ### MockGraphError
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ const link = new MockGraphLink(() => window.__MOCK_GQL_GRAPH, {
   onError: (errors, queryDocument) => {
     // report error to test runner
   },
+  fragmentIntrospectionQueryResultData: introspectionData,
+  timeoutMs: 100,
 });
 ```
 
@@ -114,6 +116,21 @@ Useful for testing; returns a promise that resolves when all active queries have
 `opts.waitToSettle?: boolean`
 
 Defaults to true. When true, will also check to see if any resolved queries have caused _other_ queries to start, and if so, will wait for those, too.
+
+Example:
+
+```js
+it('should hide save button', async () => {
+  const link = new MockGraphLink(() => mockGqlGraph);
+  const client = new ApolloClient({
+    link,
+    cache: new InMemoryCache(),
+  });
+  const wrapper = renderUi(client);
+  await link.waitForQueries();
+  expect(wrapper.find('saveButton')).not.toExist();
+});
+```
 
 ### MockGraphError
 

--- a/src/MockGraphLink.js
+++ b/src/MockGraphLink.js
@@ -32,9 +32,11 @@ class MockGraphLink extends ApolloLink {
     const {
       onError = defaultOnError,
       fragmentIntrospectionQueryResultData,
+      timeoutMs = 100,
     } = opts;
     this.getMockGraph = getMockGraph;
     this.onError = onError;
+    this.timeoutMs = timeoutMs;
 
     if (fragmentIntrospectionQueryResultData) {
       this.fragmentTypeMap = this.parseFragmentIntrospectionResult(
@@ -317,7 +319,7 @@ class MockGraphLink extends ApolloLink {
       const timeout = setTimeout(() => {
         sub.next({ data: result, errors: formattedErrors });
         sub.complete();
-      }, 100);
+      }, this.timeoutMs);
       return () => clearTimeout(timeout);
     });
   }

--- a/src/MockGraphLink.js
+++ b/src/MockGraphLink.js
@@ -336,13 +336,17 @@ class MockGraphLink extends ApolloLink {
     return observable;
   }
 
-  waitForQueries() {
-    const promises = this.queriesInFlight.values();
-    return Promise.all(promises).then(() => {
-      return {
-        numberOfQueries: promises.length,
-      };
-    });
+  async waitForQueries({ waitToSettle = true } = {}) {
+    const promises = [...this.queriesInFlight.values()];
+
+    if (promises.length) {
+      await Promise.all(promises);
+      if (waitToSettle) {
+        // wait a tick for any new queries to start
+        await new Promise(resolve => setTimeout(resolve));
+        await this.waitForQueries();
+      }
+    }
   }
 }
 

--- a/src/MockGraphLink.js
+++ b/src/MockGraphLink.js
@@ -336,16 +336,20 @@ class MockGraphLink extends ApolloLink {
     return observable;
   }
 
-  async waitForQueries({ waitToSettle = true } = {}) {
+  waitForQueries({ waitToSettle = true } = {}) {
     const promises = [...this.queriesInFlight.values()];
 
     if (promises.length) {
-      await Promise.all(promises);
-      if (waitToSettle) {
-        // wait a tick for any new queries to start
-        await new Promise(resolve => setTimeout(resolve));
-        await this.waitForQueries();
-      }
+      return Promise.all(promises).then(() => {
+        if (waitToSettle) {
+          // wait a tick for any new queries to start
+          return new Promise(resolve => setTimeout(resolve)).then(() =>
+            this.waitForQueries()
+          );
+        }
+      });
+    } else {
+      return Promise.resolve();
     }
   }
 }

--- a/test/MockGraphLink.test.js
+++ b/test/MockGraphLink.test.js
@@ -354,7 +354,6 @@ it('lets you wait for all queries to finish', async () => {
       greeting: args => `Hello, ${args.name}!`,
     },
   };
-
   const query = gql`
     query MyQuery($name: String) {
       greeting(name: $name)
@@ -376,6 +375,48 @@ it('lets you wait for all queries to finish', async () => {
     .query({
       query,
       variables: { name: 'Barney' },
+    })
+    .then(result => {
+      result2 = result;
+    });
+
+  await link.waitForQueries();
+
+  expect(result1).toEqual(
+    expect.objectContaining({ data: { greeting: 'Hello, Fred!' } })
+  );
+  expect(result2).toEqual(
+    expect.objectContaining({ data: { greeting: 'Hello, Barney!' } })
+  );
+});
+
+it('can wait for queries to settle', async () => {
+  const mockGraph = {
+    Query: {
+      greeting: args => `Hello, ${args.name}!`,
+    },
+  };
+  const query = gql`
+    query MyQuery($name: String) {
+      greeting(name: $name)
+    }
+  `;
+
+  const { client, link } = createClient(() => mockGraph);
+
+  let result1, result2;
+  client
+    .query({
+      query,
+      variables: { name: 'Fred' },
+    })
+    .then(result => {
+      result1 = result;
+
+      return client.query({
+        query,
+        variables: { name: 'Barney' },
+      });
     })
     .then(result => {
       result2 = result;


### PR DESCRIPTION
I was struggling with timing and async issues when trying to use this in unit tests, so I added a couple of new features which should make things easier:

* A `timeoutMs` option that lets you control how long the mock graph waits before resolving a query
* A `waitForQueries` function that returns a promise that resolves when all current queries are resolved.